### PR TITLE
Fix: stock을 item.stock - 현재 장바구니에 담겨있는 해당 item의 quantity를 계산해서 반환

### DIFF
--- a/orders/views.py
+++ b/orders/views.py
@@ -13,7 +13,6 @@ class CartsView(View):
     def post(self, request):
         try:
             items = json.loads(request.body)['items']
-
             for item in items:
                 cart, created       = Cart.objects.get_or_create(user_id  = request.user.id, item_id  = item["id"])
                 total_cart_quantity = Cart.objects.filter(item_id=item['id']).aggregate(total_quantity=Sum('quantity'))["total_quantity"]
@@ -33,8 +32,7 @@ class CartsView(View):
     @token_decorator
     def get(self, request):
         user   = request.user
-        carts  = Cart.objects.filter(user = user).annotate(Sum('item__cart__quantity'))
-        print(dir(carts[0].item__cart__quantity__sum))
+        carts  = Cart.objects.filter(user = user).annotate(qauntity_sum = Sum('item__cart__quantity'))
         result = {
             'carts' : [
                 {
@@ -43,7 +41,7 @@ class CartsView(View):
                     'name'      : cart.item.product.name,
                     'price'     : int(cart.item.price),
                     'size'      : cart.item.size.size_g,
-                    'stock'     : cart.item.stock - cart.item__cart__quantity__sum,
+                    'stock'     : cart.item.stock - cart.qauntity_sum,
                     'quantity'  : cart.quantity,
                     'image_url' : [image.url for image in cart.item.product.imageurl_set.all()],
                     'sub_catgory_name' : cart.item.product.sub_category.name

--- a/orders/views.py
+++ b/orders/views.py
@@ -2,7 +2,7 @@ import json
 
 from django.http                import JsonResponse
 from django.views               import View
-from django.db.models           import Sum
+from django.db.models           import Sum, F
 from django.db.models.functions import Coalesce
 
 from orders.models         import Cart
@@ -33,7 +33,8 @@ class CartsView(View):
     @token_decorator
     def get(self, request):
         user   = request.user
-        carts  = Cart.objects.filter(user = user)
+        carts  = Cart.objects.filter(user = user).annotate(Sum('item__cart_set_quantity'))
+        print(carts[2].quantity__sum)
         result = {
             'carts' : [
                 {
@@ -42,7 +43,7 @@ class CartsView(View):
                     'name'      : cart.item.product.name,
                     'price'     : int(cart.item.price),
                     'size'      : cart.item.size.size_g,
-                    'stock'     : cart.item.stock - Cart.objects.filter(item_id = cart.item.id).aggregate(stock = Coalesce(Sum('quantity'), 0))['stock'],
+                    #'stock'     : cart.item.stock - cart.aggregate(stock = Coalesce(Sum('quantity'), 0))['stock'],
                     'quantity'  : cart.quantity,
                     'image_url' : [image.url for image in cart.item.product.imageurl_set.all()],
                     'sub_catgory_name' : cart.item.product.sub_category.name

--- a/orders/views.py
+++ b/orders/views.py
@@ -1,8 +1,9 @@
 import json
 
-from django.http      import JsonResponse
-from django.views     import View
-from django.db.models import Sum
+from django.http                import JsonResponse
+from django.views               import View
+from django.db.models           import Sum
+from django.db.models.functions import Coalesce
 
 from orders.models         import Cart
 from core.token_decorators import token_decorator
@@ -27,3 +28,25 @@ class CartsView(View):
            
         except KeyError:
             return JsonResponse({'message' : 'Key Error'}, status = 400)
+
+class CartsView(View):
+    @token_decorator
+    def get(self, request):
+        user   = request.user
+        carts  = Cart.objects.filter(user = user)
+        result = {
+            'carts' : [
+                {
+                    'cart_id'   : cart.id,
+                    'items'     : cart.item_id,
+                    'name'      : cart.item.product.name,
+                    'price'     : int(cart.item.price),
+                    'size'      : cart.item.size.size_g,
+                    'stock'     : cart.item.stock - Cart.objects.filter(item_id = cart.item.id).aggregate(stock = Coalesce(Sum('quantity'), 0))['stock'],
+                    'quantity'  : cart.quantity,
+                    'image_url' : [image.url for image in cart.item.product.imageurl_set.all()],
+                    'sub_catgory_name' : cart.item.product.sub_category.name
+            }for cart in carts]
+        }
+            
+        return JsonResponse({'result' : result}, status = 200)

--- a/orders/views.py
+++ b/orders/views.py
@@ -33,8 +33,8 @@ class CartsView(View):
     @token_decorator
     def get(self, request):
         user   = request.user
-        carts  = Cart.objects.filter(user = user).annotate(Sum('item__cart_set_quantity'))
-        print(carts[2].quantity__sum)
+        carts  = Cart.objects.filter(user = user).annotate(Sum('item__cart__quantity'))
+        print(dir(carts[0].item__cart__quantity__sum))
         result = {
             'carts' : [
                 {
@@ -43,7 +43,7 @@ class CartsView(View):
                     'name'      : cart.item.product.name,
                     'price'     : int(cart.item.price),
                     'size'      : cart.item.size.size_g,
-                    #'stock'     : cart.item.stock - cart.aggregate(stock = Coalesce(Sum('quantity'), 0))['stock'],
+                    'stock'     : cart.item.stock - cart.item__cart__quantity__sum,
                     'quantity'  : cart.quantity,
                     'image_url' : [image.url for image in cart.item.product.imageurl_set.all()],
                     'sub_catgory_name' : cart.item.product.sub_category.name


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
구매기능 미구현으로 인한 재고가 감소하지않아 stock의 감소량을 현재 카트에 담겨있는 아이템들의 quantity까지 비교해서 stock으로 반환합니다.
